### PR TITLE
use tsig key when notifying remotes

### DIFF
--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -1,15 +1,16 @@
 # == Define: opendnssec::tsig
 #
 define opendnssec::remote (
-  Optional[Variant[Tea::Ipv4, Tea::Ipv4_cidr]] $address4  = undef,
-  Optional[Variant[Tea::Ipv6, Tea::Ipv6_cidr]] $address6  = undef,
-  Optional[String]                             $tsig      = undef,
-  Optional[String]                             $tsig_name = undef,
-  Tea::Port                                    $port      = 53,
+  Optional[Variant[Tea::Ipv4, Tea::Ipv4_cidr]] $address4      = undef,
+  Optional[Variant[Tea::Ipv6, Tea::Ipv6_cidr]] $address6      = undef,
+  Optional[String]                             $tsig          = undef,
+  Optional[String]                             $tsig_name     = undef,
+  Boolean                                      $sign_notifies = false,
+  Tea::Port                                    $port          = 53,
 ) {
   include ::opendnssec
   $user               = $::opendnssec::user
-  $group              = $::opendnssec::user
+  $group              = $::opendnssec::group
   $manage_ods_ksmutil = $::opendnssec::manage_ods_ksmutil
   $enabled            = $::opendnssec::enabled
   $base_dir           = $::opendnssec::remotes_dir

--- a/spec/defines/remote_spec.rb
+++ b/spec/defines/remote_spec.rb
@@ -16,7 +16,7 @@ describe 'opendnssec::remote' do
       # tsig: :undef,
       # tsig_name: :undef,
       # port: "53",
-
+      # sign_notifies: false,
     }
   end
   # add these two lines in a single test block to enable puppet and hiera debug mode
@@ -389,7 +389,12 @@ describe 'opendnssec::remote' do
           end
         end
         context 'tsig_name' do
-          before(:each) { params.merge!(tsig_name: 'test_tsig') }
+          before(:each) do
+            params.merge!(
+              tsig_name: 'test_tsig',
+              sign_notifies: true,
+            )
+          end
           it { is_expected.to compile }
           it do
             is_expected.to contain_file(
@@ -416,6 +421,7 @@ describe 'opendnssec::remote' do
               \s+<AllowNotify>
               \s+<Peer>
               \s+<Prefix>192.0.2.1</Prefix>
+              \s+<Key>test_tsig</Key>
               \s+</Peer>
               \s+</AllowNotify>
               }x,
@@ -446,6 +452,7 @@ describe 'opendnssec::remote' do
               \s+<Remote>
               \s+<Address>192.0.2.1</Address>
               \s+<Port>53</Port>
+              \s+<Key>test_tsig</Key>
               \s+</Remote>
               \s+</Notify>
               }x,
@@ -520,6 +527,7 @@ describe 'opendnssec::remote' do
               address6: '2001:DB8::1',
               port: 5353,
               tsig_name: 'test_tsig',
+              sign_notifies: true,
             )
           end
           it { is_expected.to compile }
@@ -553,9 +561,11 @@ describe 'opendnssec::remote' do
               \s+<AllowNotify>
               \s+<Peer>
               \s+<Prefix>192.0.2.1</Prefix>
+              \s+<Key>test_tsig</Key>
               \s+</Peer>
               \s+<Peer>
               \s+<Prefix>2001:DB8::1</Prefix>
+              \s+<Key>test_tsig</Key>
               \s+</Peer>
               \s+</AllowNotify>
               }x,
@@ -590,10 +600,12 @@ describe 'opendnssec::remote' do
               \s+<Remote>
               \s+<Address>192.0.2.1</Address>
               \s+<Port>5353</Port>
+              \s+<Key>test_tsig</Key>
               \s+</Remote>
               \s+<Remote>
               \s+<Address>2001:DB8::1</Address>
               \s+<Port>5353</Port>
+              \s+<Key>test_tsig</Key>
               \s+</Remote>
               \s+</Notify>
               }x,

--- a/templates/etc/opendnssec/notify_in.xml.erb
+++ b/templates/etc/opendnssec/notify_in.xml.erb
@@ -3,11 +3,17 @@
 <%- if @address4 -%>
         <Peer>
           <Prefix><%= @address4 %></Prefix>
+  <%- if @sign_notifies and @_tsig_name != 'NOKEY' -%>
+          <Key><%= @_tsig_name %></Key>
+  <%- end -%>
         </Peer>
 <%- end -%>
 <%- if @address6 -%>
         <Peer>
           <Prefix><%= @address6 %></Prefix>
+  <%- if @sign_notifies and @_tsig_name != 'NOKEY' -%>
+          <Key><%= @_tsig_name %></Key>
+  <%- end -%>
         </Peer>
 <%- end -%>
       </AllowNotify>

--- a/templates/etc/opendnssec/notify_out.xml.erb
+++ b/templates/etc/opendnssec/notify_out.xml.erb
@@ -4,12 +4,18 @@
         <Remote>
           <Address><%= @address4 %></Address>
           <Port><%= @port %></Port>
+  <%- if @sign_notifies and @_tsig_name != 'NOKEY' -%>
+          <Key><%= @_tsig_name %></Key>
+  <%- end -%>
         </Remote>
 <%- end -%>
 <%- if @address6 -%>
         <Remote>
           <Address><%= @address6 %></Address>
           <Port><%= @port %></Port>
+  <%- if @sign_notifies and @_tsig_name != 'NOKEY' -%>
+          <Key><%= @_tsig_name %></Key>
+  <%- end -%>
         </Remote>
 <%- end -%>
       </Notify>


### PR DESCRIPTION
@b4ldr created this new branch with the simplified version of setting a tsig for notifies. when you agree with this one PR9 could be discarded.