### PR TITLE
only update database for files that have been changed. this fixes the…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ jobs:
       env: CHECK=parallel_spec
     - stage: spec and lint
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
-      rvm: 2.1.9
     - stage: acceptence
       bundler_args: 
       dist: trusty

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,9 +11,8 @@ opendnssec::logging_facility: 'local0'
 opendnssec::packages:
   - opendnssec
   - xsltproc
-opendnssec::services:
-  - opendnssec-enforcer
-  - opendnssec-signer
+opendnssec::service_enforcer: opendnssec-enforcer
+opendnssec::service_signer: opendnssec-signer
 opendnssec::sqlite_packages: []
 opendnssec::mysql_packages: []
 opendnssec::repository_name: 'SoftHSM'

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -2,9 +2,8 @@ opendnssec::group: ods
 opendnssec::packages:
   - opendnssec
   - libxslt
-opendnssec::services:
-  - ods-enforcerd
-  - ods-signerd
+opendnssec::service_enforcer: ods-enforcerd
+opendnssec::service_signer: ods-signerd
 opendnssec::repository_module: /usr/lib64/pkcs11/libsofthsm2.so
 opendnssec::datastore_engine: sqlite
 opendnssec::base_dir: /var/opendnssec

--- a/manifests/addns.pp
+++ b/manifests/addns.pp
@@ -37,12 +37,4 @@ define opendnssec::addns (
     command     => "/usr/bin/xsltproc --xinclude ${xsl_file} /etc/opendnssec/addns-${name}.xml.tmp | sed 's/\sxml:base[^>]*//g' > /etc/opendnssec/addns-${name}.xml",
     refreshonly => true,
   }
-  if $manage_ods_ksmutil and $enabled {
-    exec {"Forcing ods-ksmutil to update after modifying addns-${name}.xml":
-      command     => '/usr/bin/yes | /usr/bin/ods-ksmutil update all',
-      user        => $user,
-      refreshonly => true,
-      subscribe   => Exec["write /etc/opendnssec/addns-${name}.xml"],
-    }
-  }
 }

--- a/manifests/policies.pp
+++ b/manifests/policies.pp
@@ -30,7 +30,7 @@ class opendnssec::policies (
   create_resources(opendnssec::policy, $policies)
   if $manage_ods_ksmutil and $enabled {
     exec {'ods-ksmutil updated kasp.xml':
-      command     => "/usr/bin/yes | ${ksmutil_path} update all",
+      command     => "/usr/bin/yes | ${ksmutil_path} update kasp",
       user        => $user,
       refreshonly => true,
       subscribe   => Concat[$policy_file];

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -60,17 +60,4 @@ define opendnssec::remote (
     group   => $group,
     content => template('opendnssec/etc/opendnssec/notify_out.xml.erb'),
   }
-  if $manage_ods_ksmutil and $enabled {
-    exec {"Forcing ods-ksmutil to update after modifying remote ${name}":
-      command     => '/usr/bin/yes | /usr/bin/ods-ksmutil update all',
-      user        => $user,
-      refreshonly => true,
-      subscribe   => File[
-        "${base_dir}/${name}_notify_out.xml",
-        "${base_dir}/${name}_providetransfer.xml",
-        "${base_dir}/${name}_notify_in.xml",
-        "${base_dir}/${name}_requesttransfer.xml",
-      ],
-    }
-  }
 }

--- a/manifests/tsig.pp
+++ b/manifests/tsig.pp
@@ -22,12 +22,4 @@ define opendnssec::tsig (
     group   => $group,
     content => template('opendnssec/etc/opendnssec/tsig.xml.erb'),
   }
-  if $manage_ods_ksmutil and $enabled {
-    exec {"Forcing ods-ksmutil to update after modifying ${base_dir}/${_name}.xml":
-      command     => '/usr/bin/yes | /usr/bin/ods-ksmutil update all',
-      user        => $user,
-      refreshonly => true,
-      subscribe   => File["${base_dir}/${_name}.xml"],
-    }
-  }
 }

--- a/manifests/zones.pp
+++ b/manifests/zones.pp
@@ -30,7 +30,7 @@ class opendnssec::zones (
   create_resources(opendnssec::zone, $zones)
   if $manage_ods_ksmutil and $enabled {
     exec {'ods-ksmutil updated zonelist.xml':
-      command     => "/usr/bin/yes | ${ksmutil_path} update all",
+      command     => "/usr/bin/yes | ${ksmutil_path} update zonelist",
       user        => $user,
       refreshonly => true,
       subscribe   => Concat[$zone_file];

--- a/spec/classes/opendnssec_spec.rb
+++ b/spec/classes/opendnssec_spec.rb
@@ -195,7 +195,7 @@ describe 'opendnssec' do
         end
         it do
           is_expected.to contain_exec('ods-ksmutil updated conf.xml').with(
-            command: "/usr/bin/yes | #{ksmutil_path} update all",
+            command: "/usr/bin/yes | #{ksmutil_path} update conf",
             user: 'root',
             refreshonly: true,
             subscribe: 'File[/etc/opendnssec/conf.xml]',

--- a/spec/classes/policies_spec.rb
+++ b/spec/classes/policies_spec.rb
@@ -70,7 +70,7 @@ describe 'opendnssec::policies' do
         end
         it do
           is_expected.to contain_exec('ods-ksmutil updated kasp.xml').with(
-            command: "/usr/bin/yes | #{ksmutil_path} update all",
+            command: "/usr/bin/yes | #{ksmutil_path} update kasp",
             user: 'root',
             refreshonly: true,
             subscribe: 'Concat[/etc/opendnssec/kasp.xml]',

--- a/spec/classes/zones_spec.rb
+++ b/spec/classes/zones_spec.rb
@@ -70,7 +70,7 @@ describe 'opendnssec::zones' do
         end
         it do
           is_expected.to contain_exec('ods-ksmutil updated zonelist.xml').with(
-            command: "/usr/bin/yes | #{ksmutil_path} update all",
+            command: "/usr/bin/yes | #{ksmutil_path} update zonelist",
             user: 'root',
             refreshonly: true,
             subscribe: 'Concat[/etc/opendnssec/zonelist.xml]',

--- a/spec/defines/addns_spec.rb
+++ b/spec/defines/addns_spec.rb
@@ -71,16 +71,6 @@ describe 'opendnssec::addns' do
             }x,
           )
         end
-        it do
-          is_expected.to contain_exec(
-            'Forcing ods-ksmutil to update after modifying addns-test_addns.xml',
-          ).with(
-            command: '/usr/bin/yes | /usr/bin/ods-ksmutil update all',
-            user: 'root',
-            refreshonly: true,
-            subscribe: 'Exec[write /etc/opendnssec/addns-test_addns.xml]',
-          )
-        end
       end
       describe 'Change Defaults' do
         context 'masters' do
@@ -200,11 +190,6 @@ describe 'opendnssec::addns' do
             is_expected.to contain_file(
               '/etc/opendnssec/addns-test_addns.xml.tmp',
             ).with_owner('foobar')
-          end
-          it do
-            is_expected.to contain_exec(
-              'Forcing ods-ksmutil to update after modifying addns-test_addns.xml',
-            ).with_user('foobar')
           end
         end
         context 'opendnssec::group' do

--- a/spec/defines/remote_spec.rb
+++ b/spec/defines/remote_spec.rb
@@ -107,21 +107,6 @@ describe 'opendnssec::remote' do
             }x,
           )
         end
-        it do
-          is_expected.to contain_exec(
-            'Forcing ods-ksmutil to update after modifying remote test_remote',
-          ).with(
-            command: '/usr/bin/yes | /usr/bin/ods-ksmutil update all',
-            user: 'root',
-            refreshonly: true,
-            subscribe: [
-              'File[/etc/opendnssec/remotes/test_remote_notify_out.xml]',
-              'File[/etc/opendnssec/remotes/test_remote_providetransfer.xml]',
-              'File[/etc/opendnssec/remotes/test_remote_notify_in.xml]',
-              'File[/etc/opendnssec/remotes/test_remote_requesttransfer.xml]',
-            ],
-          )
-        end
       end
       describe 'Change Defaults' do
         context 'address4' do

--- a/spec/defines/tsig_spec.rb
+++ b/spec/defines/tsig_spec.rb
@@ -56,16 +56,6 @@ describe 'opendnssec::tsig' do
             }x,
           )
         end
-        it do
-          is_expected.to contain_exec(
-            'Forcing ods-ksmutil to update after modifying /etc/opendnssec/tsigs/test_tsig.xml',
-          ).with(
-            command: '/usr/bin/yes | /usr/bin/ods-ksmutil update all',
-            user: 'root',
-            refreshonly: true,
-            subscribe: 'File[/etc/opendnssec/tsigs/test_tsig.xml]',
-          )
-        end
       end
       describe 'Change Defaults' do
         context 'key_name' do

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -70,11 +70,6 @@ describe 'opendnssec::zone' do
           )
         end
         it do
-          is_expected.to contain_exec(
-            'Forcing ods-ksmutil to update after modifying addns-default.xml',
-          )
-        end
-        it do
           is_expected.to contain_concat__fragment('zone_test_zone').with(
             target: '/etc/opendnssec/zonelist.xml',
             order: '10',
@@ -142,11 +137,6 @@ describe 'opendnssec::zone' do
             )
           end
           it do
-            is_expected.to contain_exec(
-              'Forcing ods-ksmutil to update after modifying addns-test_zone-masters.xml',
-            )
-          end
-          it do
             is_expected.to contain_concat__fragment(
               'zone_test_zone',
             ).with_content(
@@ -173,11 +163,6 @@ describe 'opendnssec::zone' do
           it do
             is_expected.to contain_file(
               '/etc/opendnssec/addns-test_zone-provide_xfrs.xml.tmp',
-            )
-          end
-          it do
-            is_expected.to contain_exec(
-              'Forcing ods-ksmutil to update after modifying addns-test_zone-provide_xfrs.xml',
             )
           end
           it do


### PR DESCRIPTION
This is an update to PR4 (https://github.com/icann-dns/puppet-opendnssec/pull/4) to work with the latest version of the code.

This solves the bug, that config is read in the wrong order/at the wrong time. We ran in to the issue that the zonelist.xml was read before it was fully propagated/created. It was deleting (KSK/ZSK) keys from the existing database for zones that were not yet available in zonelist.xml, and creating new keys for these zones as soon as they were in the zonelist.xml
