### PR TITLE
feat: allow disabling notifies per remote

### DIFF
--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -6,6 +6,7 @@ define opendnssec::remote (
   Optional[String]                             $tsig          = undef,
   Optional[String]                             $tsig_name     = undef,
   Boolean                                      $sign_notifies = false,
+  Boolean                                      $send_notifies = true,
   Tea::Port                                    $port          = 53,
 ) {
   include ::opendnssec
@@ -42,22 +43,27 @@ define opendnssec::remote (
     group   => $group,
     content => template('opendnssec/etc/opendnssec/requesttransfer.xml.erb'),
   }
-  file{ "${base_dir}/${name}_notify_in.xml":
-    ensure  => file,
-    owner   => $user,
-    group   => $group,
-    content => template('opendnssec/etc/opendnssec/notify_in.xml.erb'),
+
+  if $send_notifies {
+    file{ "${base_dir}/${name}_notify_in.xml":
+      ensure  => file,
+      owner   => $user,
+      group   => $group,
+      content => template('opendnssec/etc/opendnssec/notify_in.xml.erb'),
+    }
+
+    file{ "${base_dir}/${name}_notify_out.xml":
+      ensure  => file,
+      owner   => $user,
+      group   => $group,
+      content => template('opendnssec/etc/opendnssec/notify_out.xml.erb'),
+    }
   }
+
   file{ "${base_dir}/${name}_providetransfer.xml":
     ensure  => file,
     owner   => $user,
     group   => $group,
     content => template('opendnssec/etc/opendnssec/providetransfer.xml.erb'),
-  }
-  file{ "${base_dir}/${name}_notify_out.xml":
-    ensure  => file,
-    owner   => $user,
-    group   => $group,
-    content => template('opendnssec/etc/opendnssec/notify_out.xml.erb'),
   }
 }

--- a/templates/etc/opendnssec/addns.xml.erb
+++ b/templates/etc/opendnssec/addns.xml.erb
@@ -44,7 +44,7 @@
       </ProvideTransfer>
       <Notify>
   <%- @provide_xfrs.each do |provide_xfr| -%>
-    <%- if @remotes[provide_xfr].include?('address4') -%>
+    <%- if @remotes[provide_xfr].fetch("send_notifies", true) -%>
         <xi:include href="<%= @remotes_dir %>/<%= provide_xfr %>_notify_out.xml"
             xpointer="xpointer(//Notify/Remote)" />
     <%- end -%>


### PR DESCRIPTION
Currently when configuring a remote, zone update notifies are sent by default with no way to opt-out. We've had some use-cases where we do want to allow zone transfers for a specific remote, but don't send out zone notifies (because for example no DNS server is listening a given remote, causing errors in the opendnssec logs).

This PR addresses this issue by adding the `enable_notifies` flag for a remote. When set to true, notifies are sent for the given remote. When set to false, notifies are not sent to the remote, but zone transfers initiated by the remote are still allowed. By default this flag is set to true, so it doesn't change the current behavior.