### PR TITLE
Adding OpenDNSSEC version 2 conf.xml compliant

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,6 +6,7 @@ opendnssec::manage_datastore: true
 opendnssec::manage_service: true
 opendnssec::manage_ods_ksmutil: true
 opendnssec::manage_conf: true
+opendnssec::opendnssec_version_1: true
 opendnssec::logging_level: 3
 opendnssec::logging_facility: 'local0'
 opendnssec::packages:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,7 +6,7 @@ opendnssec::manage_datastore: true
 opendnssec::manage_service: true
 opendnssec::manage_ods_ksmutil: true
 opendnssec::manage_conf: true
-opendnssec::opendnssec_version_1: true
+opendnssec::opendnssec_version: '1'
 opendnssec::logging_level: 3
 opendnssec::logging_facility: 'local0'
 opendnssec::packages:

--- a/manifests/backup_cron.pp
+++ b/manifests/backup_cron.pp
@@ -12,9 +12,9 @@ class opendnssec::backup_cron (
   Boolean              $require_backup,
 ) {
   include ::opendnssec
-  $user             = $::opendnssec::user
-  $group            = $::opendnssec::group
-  $datastore_engine = $::opendnssec::datastore_engine
+  $user               = $::opendnssec::user
+  $group              = $::opendnssec::group
+  $datastore_engine   = $::opendnssec::datastore_engine
 
   file {[$backup_dir, $tmp_dirbase]:
     ensure => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,8 @@ class opendnssec (
   Boolean                       $manage_ods_ksmutil,
   Boolean                       $manage_conf,
 
+  Boolean                       $opendnssec_version_1,
+
   Integer[1,7]                  $logging_level,
   Tea::Syslogfacility           $logging_facility,
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class opendnssec (
   Boolean                       $manage_ods_ksmutil,
   Boolean                       $manage_conf,
 
-  Boolean                       $opendnssec_version_1,
+  String[1,10]                  $opendnssec_version,
 
   Integer[1,7]                  $logging_level,
   Tea::Syslogfacility           $logging_facility,

--- a/spec/classes/opendnssec_spec.rb
+++ b/spec/classes/opendnssec_spec.rb
@@ -16,6 +16,7 @@ describe 'opendnssec' do
       #:manage_service => true,
       #:manage_ods_ksmutil => true,
       #:manage_conf => true,
+	  #:opendnssec_version_1 => true,
       #:manage_policies => true,
       #:policies => {},
       #:manage_zones => true,

--- a/spec/classes/opendnssec_spec.rb
+++ b/spec/classes/opendnssec_spec.rb
@@ -16,7 +16,7 @@ describe 'opendnssec' do
       #:manage_service => true,
       #:manage_ods_ksmutil => true,
       #:manage_conf => true,
-	  #:opendnssec_version_1 => true,
+	  #:opendnssec_version => '1',
       #:manage_policies => true,
       #:policies => {},
       #:manage_zones => true,

--- a/templates/etc/opendnssec/conf.xml.erb
+++ b/templates/etc/opendnssec/conf.xml.erb
@@ -51,9 +51,9 @@
       <SQLite><%= @sqlite_file %></SQLite>
 <%- elsif @datastore_engine == 'mysql' -%>
       <MySQL>
-<%- if @opendnssec_version_1 -%>
+<%- if @opendnssec_version == '1' -%>
         <Host port="<%= @datastore_port %>"><%= @datastore_host %></Host>
-<%- else -%>
+<%- elsif @opendnssec_version == '2' -%>
         <Host Port="<%= @datastore_port %>"><%= @datastore_host %></Host>
 <%- end -%>
         <Database><%= @datastore_name %></Database>
@@ -62,7 +62,7 @@
       </MySQL>
 <%- end -%>
     </Datastore>
-<%- if @opendnssec_version_1 -%>
+<%- if @opendnssec_version == '1' -%>    
     <Interval>PT3600S</Interval>
 <%- end -%>
     <!-- <ManualKeyGeneration/> -->

--- a/templates/etc/opendnssec/conf.xml.erb
+++ b/templates/etc/opendnssec/conf.xml.erb
@@ -51,14 +51,20 @@
       <SQLite><%= @sqlite_file %></SQLite>
 <%- elsif @datastore_engine == 'mysql' -%>
       <MySQL>
+<%- if @opendnssec_version_1 -%>
         <Host port="<%= @datastore_port %>"><%= @datastore_host %></Host>
+<%- else -%>
+        <Host Port="<%= @datastore_port %>"><%= @datastore_host %></Host>
+<%- end -%>
         <Database><%= @datastore_name %></Database>
         <Username><%= @datastore_user %></Username>
         <Password><%= @datastore_password %></Password>
       </MySQL>
 <%- end -%>
     </Datastore>
+<%- if @opendnssec_version_1 -%>
     <Interval>PT3600S</Interval>
+<%- end -%>
     <!-- <ManualKeyGeneration/> -->
     <!-- <RolloverNotification>P14D</RolloverNotification> -->
 


### PR DESCRIPTION
Adding parameter `opendnssec_version` to support new version of `conf.xml` in OpenDNSSEC
